### PR TITLE
fix: make sensor template non-blocking and support concurrent clients

### DIFF
--- a/lunarsensor.py
+++ b/lunarsensor.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import time
+import asyncio
 
 import aiohttp
 from fastapi import FastAPI, Request
@@ -12,11 +13,10 @@ logging.basicConfig()
 log = logging.getLogger("lunarsensor")
 log.level = logging.DEBUG if os.getenv("SENSOR_DEBUG") == "1" else logging.INFO
 
-
 POLLING_SECONDS = 2
 CLIENT = None
 last_lux = 400
-
+sensor_lock = asyncio.Lock()  # serialize sensor or file access
 
 @app.on_event("startup")
 async def startup_event():
@@ -25,11 +25,9 @@ async def startup_event():
     CLIENT = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=8))
     await CLIENT.__aenter__()
 
-
 @app.on_event("shutdown")
 async def shutdown() -> None:
     await CLIENT.__aexit__(None, None, None)
-
 
 async def make_lux_response():
     global last_lux
@@ -44,31 +42,30 @@ async def make_lux_response():
 
     return {"id": "sensor-ambient_light", "state": f"{last_lux} lx", "value": last_lux}
 
-
 async def sensor_reader(request):
     while not await request.is_disconnected():
         yield {"event": "state", "data": json.dumps(await make_lux_response())}
-
-        time.sleep(POLLING_SECONDS)
-
+        await asyncio.sleep(POLLING_SECONDS)
 
 @app.get("/sensor/ambient_light")
 async def sensor():
     return await make_lux_response()
-
 
 @app.get("/events")
 async def events(request: Request):
     event_generator = sensor_reader(request)
     return EventSourceResponse(event_generator)
 
-
-# Do the sensor reading logic below
-
-
-async def read_lux():
+# Synchronous helper for reading lux (e.g. from file or sensor)
+def _sync_read_lux():
     if os.path.exists("/tmp/lux"):
         with open("/tmp/lux") as f:
             return float(f.read().strip() or "400.0")
+    return 400.0
 
-    return 400.00
+async def read_lux():
+    # Offload potentially blocking I/O into executor, serializing with a lock
+    loop = asyncio.get_running_loop()
+    async with sensor_lock:
+        lux = await loop.run_in_executor(None, _sync_read_lux)
+    return lux


### PR DESCRIPTION
1. Import asyncio and introduce a module-level sensor_lock to serialize access to blocking I/O (e.g., file or sensor reads).
2. Replace time.sleep in sensor_reader with await asyncio.sleep so the event loop isn’t blocked and multiple SSE clients can receive updates concurrently.
3. Extract the original blocking read logic into a synchronous helper (_sync_read_lux), then offload it to the default executor via loop.run_in_executor under the lock to prevent I²C (or file) collisions.
4. Keep all existing endpoints, logging, and configuration intact.